### PR TITLE
Setting .env

### DIFF
--- a/.env.xml.sample
+++ b/.env.xml.sample
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <UNITY_ENGINE_DIR>C:\Program Files\Unity\Hub\Editor\2021.3.0f1\Editor\Data\Managed\UnityEngine</UNITY_ENGINE_DIR>
+  </PropertyGroup>
+</Project>

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ xunit.runner.console.*/
 Thumbs.db
 Desktop.ini
 .DS_Store
+
+# env
+.env.xml

--- a/Libplanet.Unity/Libplanet.Unity.csproj
+++ b/Libplanet.Unity/Libplanet.Unity.csproj
@@ -69,19 +69,21 @@
     <ProjectReference Include="..\libplanet\Libplanet.Net\Libplanet.Net.csproj" />
     <ProjectReference Include="..\libplanet\Libplanet\Libplanet.csproj" />
   </ItemGroup>
-
+  
+  <!-- Fixed in 2021 version -->
+  <Import Project="..\.env.xml"></Import>
   <ItemGroup>
     <Reference Include="UnityEngine">
-      <HintPath>.\UnityReference\UnityEngine.dll</HintPath>
+        <HintPath>$(UNITY_ENGINE_DIR)\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>.\UnityReference\UnityEngine.CoreModule.dll</HintPath>
+        <HintPath>$(UNITY_ENGINE_DIR)\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEditor">
-      <HintPath>.\UnityReference\UnityEditor.dll</HintPath>
+        <HintPath>$(UNITY_ENGINE_DIR)\UnityEditor.dll</HintPath>
     </Reference>
     <Reference Include="UnityEditor.CoreModule">
-      <HintPath>.\UnityReference\UnityEditor.CoreModule.dll</HintPath>
+        <HintPath>$(UNITY_ENGINE_DIR)\UnityEditor.CoreModule.dll</HintPath>
     </Reference>
   </ItemGroup>
   

--- a/Libplanet.Unity/UnityReference/.gitignore
+++ b/Libplanet.Unity/UnityReference/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # Libplanet Unity SDK
+
+# Setup
+Windows
+```
+# Power Shell
+
+.\scripts\create-dotenv.ps1
+```

--- a/libplanet-unity-sdk.sln
+++ b/libplanet-unity-sdk.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30114.105
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Libplanet.Unity", "Libplanet.Unity\Libplanet.Unity.csproj", "{A04E7633-C242-4940-87EE-20980D346EC6}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A04E7633-C242-4940-87EE-20980D346EC6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A04E7633-C242-4940-87EE-20980D346EC6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A04E7633-C242-4940-87EE-20980D346EC6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A04E7633-C242-4940-87EE-20980D346EC6}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/scripts/create-dotenv.ps1
+++ b/scripts/create-dotenv.ps1
@@ -1,0 +1,50 @@
+$ENV_PATH = ".\.env.xml"
+
+$expected_paths = Get-ChildItem -Path "\Program Files" -Filter "unity.exe" -Recurse | Select-Object Fullname | Format-List | Out-String
+$expected_paths = $expected_paths.Split("`n", [StringSplitOptions]::RemoveEmptyEntries)
+
+$unity_paths = @()
+
+foreach ($p in $expected_paths) {
+    if ($p) {
+        $path_data = [regex]::Match($p, '^FullName\s:\s(.*)Unity.exe').captures.groups
+        if ($path_data) {
+            $unity_paths = $unity_paths + $path_data[1].value
+        }
+    }
+}
+
+$TARGET_PATH = "null"
+
+do {
+    $option = 1
+    foreach ($p in $unity_paths) {
+        Write-Output $option" - [ "$p" ]"
+        $option++
+    }
+
+    Write-Output ""
+    $Prompt = Read-host "Pls Select"
+    if ( ($Prompt -gt 0 -and $Prompt -lt $option) ) {
+        $TARGET_PATH = $unity_paths[$Prompt - 1]
+        Write-Output ""
+        Write-Output "Selected Path"$TARGET_PATH
+        Write-Output ""
+    }
+    else {
+        Write-Output ""
+        Write-Output "Wrong Selection!"
+        Write-Output ""
+    }
+} while ($TARGET_PATH -eq "null")
+
+$UNITY_ENGINE_DIR = "$TARGET_PATH\Data\Managed\UnityEngine\"
+
+$xml_value = "<Project>
+`t<PropertyGroup>
+`t`t<UNITY_ENGINE_DIR>$UNITY_ENGINE_DIR</UNITY_ENGINE_DIR>
+`t</PropertyGroup>
+</Project>"
+
+New-Item $ENV_PATH -ItemType File
+Set-Content $ENV_PATH $xml_value

--- a/scripts/create-dotenv.ps1
+++ b/scripts/create-dotenv.ps1
@@ -38,7 +38,7 @@ do {
     }
 } while ($TARGET_PATH -eq "null")
 
-$UNITY_ENGINE_DIR = "$TARGET_PATH\Data\Managed\UnityEngine\"
+$UNITY_ENGINE_DIR = "$TARGET_PATH\Data\Managed\UnityEngine"
 
 $xml_value = "<Project>
 `t<PropertyGroup>


### PR DESCRIPTION
Add `create-dotenv.ps1`

`create-dotenv.ps1` can create  `.env.xml` file by reading the locally installed unity path.
`.env.xml` is used as the `PropertyGroup` in `Libplanet.Unity.csproj`